### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,4 +1,6 @@
 name: Backend CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FlaccidFacade/7hand/security/code-scanning/1](https://github.com/FlaccidFacade/7hand/security/code-scanning/1)

The best and most conservative fix is to add a `permissions` block restricting the GITHUB_TOKEN to read-only access to repository contents. This can be added to the root of the workflow file, just below the `name:` line (at the workflow level), so all jobs inherit the minimal permissions. The most minimal required setting is:

```yaml
permissions:
  contents: read
```

This restricts the GITHUB_TOKEN to only being able to read repository contents, preventing accidental privileges escalation.

**Where to edit:**  
In `.github/workflows/backend-ci.yml`, add the `permissions:` block after `name: Backend CI`, and before `on:`.

**What else is needed:**  
No additional imports or methods—this is purely a YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
